### PR TITLE
Fix the library dependency

### DIFF
--- a/ConsoleApp/ConsoleApp.pro
+++ b/ConsoleApp/ConsoleApp.pro
@@ -22,7 +22,7 @@ HEADERS  += mainwindow.h \
 
 FORMS    += mainwindow.ui
 
-win32: LIBS += -L$$PWD/./ -lnicanmsc
+win32: LIBS += -L$$(NIEXTCCOMPILERSUPP)/Lib32/MSVC/ -lnicanmsc
 
 INCLUDEPATH += $$PWD/.
 DEPENDPATH += $$PWD/.

--- a/ConsoleApp/mainwindow.ui
+++ b/ConsoleApp/mainwindow.ui
@@ -55,8 +55,8 @@
      <rect>
       <x>280</x>
       <y>80</y>
-      <width>75</width>
-      <height>23</height>
+      <width>91</width>
+      <height>31</height>
      </rect>
     </property>
     <property name="text">
@@ -70,7 +70,7 @@
      <x>0</x>
      <y>0</y>
      <width>560</width>
-     <height>21</height>
+     <height>26</height>
     </rect>
    </property>
   </widget>

--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
 # QtNiCanConsole
 
 This application is a console application that will allow you to interface with the NI-8473 CAN box.  The QT based application shows messages that are received and allows you to send generic CAN messages you construct.  This allows you to easily test other CAN nodes for operation.
+
+*NOTES:
+1. Assumes the environment variables NIEXTCCOMPILERSUPP is set.  This should happen if you have installed the required libraries if not then you can point it to C:\Program Files (x86)\National Instruments\Shared\ExternalCompilerSupport\C\


### PR DESCRIPTION
Now the project does not require the nican library to be copied into the
project directory it uses the one that is installed in the NI folder
structure.
